### PR TITLE
ci: upgrade nr deploy dependency (breaking changes introduced)

### DIFF
--- a/.github/workflows/report_deploy-NR.yml
+++ b/.github/workflows/report_deploy-NR.yml
@@ -7,13 +7,14 @@ on:
       NR_API_KEY:
         description: 'New Relic API KEY'
         required: true
-      NR_ACCOUNT_ID:
-        description: 'New Relic account ID'
-        required: true
     inputs:
-      NR_APP_ID:
-        description: 'New Relic application ID'
+      NR_ENTITY_GUID:
+        description: 'New Relic entity GUID'
         required: true
+        type: string
+      VERSION:
+        description: 'Version of deployed app'
+        required: false
         type: string
       DESCRIPTION:
         description: 'Description of deployed version'
@@ -25,10 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: New Relic Deployment Report
-        uses: newrelic/deployment-marker-action@v1.0.0
+        uses: newrelic/deployment-marker-action@v2.2.0
         with:
           apiKey: ${{ secrets.NR_API_KEY }}
-          accountId: ${{ secrets.NR_ACCOUNT_ID }}
-          applicationId: ${{ inputs.NR_APP_ID }}
-          revision: ${{ github.sha }}
+          guid: ${{ inputs.NR_ENTITY_GUID }}
+          version: ${{ inputs.VERSION || inputs.github.sha }}
           description: ${{ inputs.DESCRIPTION }}

--- a/.github/workflows/report_deploy.yml
+++ b/.github/workflows/report_deploy.yml
@@ -13,9 +13,6 @@ on:
       NR_API_KEY:
         description: 'New Relic API KEY'
         required: false
-      NR_ACCOUNT_ID:
-        description: 'New Relic account ID'
-        required: false
       VELOCITY_TOKEN:
         description: 'Velocity Token'
         required: false
@@ -28,12 +25,16 @@ on:
         description: 'Slack channel to report'
         required: false
         type: string
-      NR_APP_ID:
-        description: 'New Relic application ID'
+      NR_ENTITY_GUID:
+        description: 'New Relic entity GUID'
         required: false
         type: string
       ENVIRONMENT:
         description: 'Environment of deployed app (for velocity)'
+        required: false
+        type: string
+      VERSION:
+        description: 'Version of deployed app'
         required: false
         type: string
       DESCRIPTION:
@@ -50,11 +51,12 @@ jobs:
       FAILURE: ${{ inputs.FAILURE }}
       SLACK_CHANNEL: ${{ inputs.SLACK_CHANNEL }}
   new-relic:
-    if: ${{ !inputs.FAILURE && inputs.NR_APP_ID != '' }}
+    if: ${{ !inputs.FAILURE && inputs.NR_ENTITY_GUID != '' }}
     uses: ./.github/workflows/report_deploy-NR.yml
     secrets: inherit
     with:
-      NR_APP_ID: ${{ inputs.NR_APP_ID }}
+      NR_ENTITY_GUID: ${{ inputs.NR_ENTITY_GUID }}
+      VERSION: ${{ inputs.VERSION }}
       DESCRIPTION: ${{ inputs.DESCRIPTION }}
   velocity:
     if: ${{ !inputs.FAILURE && inputs.ENVIRONMENT != '' }}


### PR DESCRIPTION
Atualiza o action de reportar o deploy pro new-relic para utilizar a nova versão da API de deploy deles e também a nova versão do action, que remove features _deprecated_