### PR TITLE
ci(report-deploy): add dafult description

### DIFF
--- a/.github/workflows/report_deploy.yml
+++ b/.github/workflows/report_deploy.yml
@@ -41,6 +41,7 @@ on:
         description: 'Description of deployed version'
         required: false
         type: string
+        default: 'Github Actions Deploy'
         
 jobs:
   slack:


### PR DESCRIPTION
Coloquei uma mensagem pra avisar que os deploys foram feitos pelo github actions. Futuramente podemos reportar o deploy do argo, por exemplo, quando revertemos algo.