### PR TITLE
Refactor/upgrade dependencies

### DIFF
--- a/.github/workflows/java_gradle-analyze-sonar.yml
+++ b/.github/workflows/java_gradle-analyze-sonar.yml
@@ -35,7 +35,7 @@ on:
         description: 'Java version'
         required: false
         type: string
-        default: '16'
+        default: '17'
       JAVA_DISTRIBUTION:
         description: 'Java distribution'
         required: false

--- a/.github/workflows/scan_secrets-git.yml
+++ b/.github/workflows/scan_secrets-git.yml
@@ -1,17 +1,21 @@
-# Secret security scan
-name: Secret security scan
+name: Secrets security scan
 
 on:
   workflow_call:
+    secrets:
+      GITLEAKS_LICENSE:
+          description: 'Organization gitleaks license'
+          required: true
 
 jobs:
-  security-scan:
+  scan-secrets:
     runs-on: ubuntu-latest
-    name: Security scan
+    name: gitleaks
     steps:
       - uses: actions/checkout@v3
-      - name: scan-secrets
-        run: |
-          DOCKER_USER_ID="$(id -u)"
-          docker image pull zricethezav/gitleaks:v8.8.4
-          docker run -u ${DOCKER_USER_ID} -v ${GITHUB_WORKSPACE}:/path zricethezav/gitleaks:v8.8.4 detect --source="/path" -v
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/scan_secrets-git.yml
+++ b/.github/workflows/scan_secrets-git.yml
@@ -13,8 +13,6 @@ jobs:
     name: gitleaks
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scan_secrets-git.yml
+++ b/.github/workflows/scan_secrets-git.yml
@@ -13,7 +13,12 @@ jobs:
     name: gitleaks
     steps:
       - uses: actions/checkout@v3
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+      - name: scan-secrets
+        run: |
+          DOCKER_USER_ID="$(id -u)"
+          docker image pull zricethezav/gitleaks:v8.18.0
+          docker run -u ${DOCKER_USER_ID} -v ${GITHUB_WORKSPACE}:/path zricethezav/gitleaks:v8.18.0 detect --source="/path" -v
+      # - uses: gitleaks/gitleaks-action@v2
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
- Atualiza o scan do sonar para usar o java 17 por default e evitar um warning de depreciação (provavelmente em breve deixará de funcionar se continuar usando uma imagem do java 16)
- Atualiza o scan secrets pra usar o action oficial do gitleaks, ele imprime os resultados de forma mais organizada